### PR TITLE
fix: default text mapping work properly

### DIFF
--- a/re-name-favbar/background.js
+++ b/re-name-favbar/background.js
@@ -1,3 +1,43 @@
+chrome.runtime.onInstalled.addListener((details) => {
+  if (details.reason === 'install') {
+    const defaultMapping = {
+      'API Gateway': 'API GW',
+      'Application Discovery Service': 'ADS',
+      'AppStream 2.0': 'AppStream',
+      'AWS Auto Scaling': 'ASG',
+      'Certificate Manager': 'ACM',
+      CloudFormation: 'CFN',
+      CloudFront: 'CF',
+      CloudHSM: 'HSM',
+      CloudSearch: 'CS',
+      CloudWatch: 'CW',
+      'Database Migration Service': 'DMS',
+      'Direct Connect': 'DX',
+      DynamoDB: 'DDB',
+      'Elastic Beanstalk': 'EB',
+      'Elastic Container Registry': 'ECR',
+      'Elastic Container Service': 'ECS',
+      'Elastic Kubernetes Service': 'EKS',
+      'IoT Device Management': 'IoT DM',
+      'Key Management Service': 'KMS',
+      'Managed Apache Airflow': 'MAA',
+      'Resource Access Manager': 'RAM',
+      'Route 53': 'R53',
+      'Service Catalog': 'SC',
+      'Simple Notification Service': 'SNS',
+      'Simple Queue Service': 'SQS',
+      'Step Functions': 'SF',
+      'Storage Gateway': 'SG',
+      'Systems Manager': 'SSM',
+      'Trusted Advisor': 'TA',
+      'WAF & Shield': 'WAF',
+    };
+    chrome.storage.sync.set({ textMappings: defaultMapping }, function () {
+      console.log('Default textMappings set');
+    });
+  }
+});
+
 init = (tab) => {
   if (!tab) {
     console.log('Tab not found');

--- a/re-name-favbar/options.js
+++ b/re-name-favbar/options.js
@@ -1,47 +1,6 @@
-// Default mapping between AWS service names and their renamed versions.
-const defaultMapping = {
-  'API Gateway': 'API GW',
-  'Application Discovery Service': 'ADS',
-  'AppStream 2.0': 'AppStream',
-  'AWS Auto Scaling': 'ASG',
-  'Certificate Manager': 'ACM',
-  CloudFormation: 'CFN',
-  CloudFront: 'CF',
-  CloudHSM: 'HSM',
-  CloudSearch: 'CS',
-  CloudWatch: 'CW',
-  'Database Migration Service': 'DMS',
-  'Direct Connect': 'DX',
-  DynamoDB: 'DDB',
-  'Elastic Beanstalk': 'EB',
-  'Elastic Container Registry': 'ECR',
-  'Elastic Container Service': 'ECS',
-  'Elastic Kubernetes Service': 'EKS',
-  'IoT Device Management': 'IoT DM',
-  'Key Management Service': 'KMS',
-  'Managed Apache Airflow': 'MAA',
-  'Resource Access Manager': 'RAM',
-  'Route 53': 'R53',
-  'Service Catalog': 'SC',
-  'Simple Notification Service': 'SNS',
-  'Simple Queue Service': 'SQS',
-  'Step Functions': 'SF',
-  'Storage Gateway': 'SG',
-  'Systems Manager': 'SSM',
-  'Trusted Advisor': 'TA',
-  'WAF & Shield': 'WAF',
-};
-
 // Attach event listeners to buttons for saving and resetting options.
 document.getElementById('saveButton').addEventListener('click', saveOptions);
 document.getElementById('resetButton').addEventListener('click', resetOptions);
-
-// When the extension is installed, load the default mappings into storage and display them on the options page.
-chrome.runtime.onInstalled.addListener(function () {
-  chrome.storage.sync.set({ textMappings: defaultMapping }, function () {
-    populateOptions();
-  });
-});
 
 // When the options page is loaded, display the current mappings.
 document.addEventListener('DOMContentLoaded', populateOptions);


### PR DESCRIPTION
- fix #13 
- move the onInstalled event listener to background.js file

> In Manifest V3, service worker background scripts (like background.js in your case) and other scripts (like options.js) have separate contexts, and events are not shared across them. This means that the onInstalled event handler in options.js will not be triggered when the extension is installed, and thus the default settings will not be stored.

